### PR TITLE
Changing mysql-connector-java to mysql-connector-j

### DIFF
--- a/guacamole.json
+++ b/guacamole.json
@@ -7,7 +7,7 @@
         "guacamole-server",
         "guacamole-client",
         "mysql80-server",
-        "mysql-connector-java"
+        "mysql-connector-j"
     ],
     "properties": {
         "nat": 1,

--- a/post_install.sh
+++ b/post_install.sh
@@ -14,7 +14,7 @@ mkdir /usr/local/etc/guacamole-client/lib
 mkdir /usr/local/etc/guacamole-client/extensions
 
 # Extract java connector to guacamole
-cp /usr/local/share/java/classes/mysql-connector-java.jar /usr/local/etc/guacamole-client/lib
+cp /usr/local/share/java/classes/mysql-connector-j.jar /usr/local/etc/guacamole-client/lib/mysql-connector-java.jar
 tar xvfz /usr/local/share/guacamole-client/guacamole-auth-jdbc.tar.gz -C /tmp/
 cp /tmp/guacamole-auth-jdbc-*/mysql/*.jar /usr/local/etc/guacamole-client/extensions
 
@@ -53,12 +53,12 @@ cat <<EOF > /root/PLUGIN_INFO
 #---------------------------------------------------------------------#
 # Getting started with the Guacamole plugin
 #---------------------------------------------------------------------#
-Apache Guacamole is a clientless remote desktop gateway. 
+Apache Guacamole is a clientless remote desktop gateway.
 It supports standard protocols like VNC, RDP, and SSH.
-Because the Guacamole client is an HTML5 web application, 
+Because the Guacamole client is an HTML5 web application,
 use of your computers is not tied to any one device or location
 Source: https://guacamole.apache.org/
- 
+
 The default user for the Admin Portal is "guacadmin" with password "guacadmin"
 MySQL Username: root
 MySQL Password: "$mysqlroot"


### PR DESCRIPTION
It looks like the package `mysql-connector-java` is no longer available. 

```
# pkg search mysql-connector-
mysql-connector-c++-8.0.33_1   MySQL database connector for C++
mysql-connector-j-8.1.0        MySQL Connector/J: JDBC interface for MySQL
mysql-connector-java51-5.1.49  MySQL Connector/J: JDBC interface for MySQL
mysql-connector-odbc-unixodbc-mysql80-8.0.32 ODBC driver for MySQL80 / unixodbc
py39-mysql-connector-python-8.2.0 MySQL driver written in Python
```

I tried with `mysql-connector-java51-5.1.49` and had issues. Then I tried with `mysql-connector-j-8.1.0` and it worked. 

More information is also available here - https://www.freshports.org/databases/mysql-connector-java/

> Conflicts:
>    CONFLICTS_INSTALL:
>
>       mysql-connector-java51
>
>Conflicts Matches:
>    There are no Conflicts Matches for this port. This is usually an error.
>No installation instructions:
>    This port has been deleted.

I tried my changes with 13.2 in iocage with 'latest' and 'quartely' and they both worked. 

See also #2.
